### PR TITLE
Add directory variable for LocalHomePage root

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -11,6 +11,8 @@
 *  
 */
 
+/** LocalHomePage root **/
+$projroot = './';
 
 /** directory name(s) */
 $dir = array("/Users/username/Sites/*");

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Local</title>
         <meta name="viewport" content="width=device-width">
-        <link rel="stylesheet" href="css/main.css">
+        <link rel="stylesheet" href="<?= $projroot ?>css/main.css">
     </head>
 
     <body>


### PR DESCRIPTION
Adds a variable $projectroot in the config default set to './'  for the ability to change where LocalHomePage is located in relation to where you're loading from.

Use case example:

- All code stashed in ~/Code, root .dev points to it
- LocalHomePage exists at ~/Code/LocalHomePage
- symlink ~/Code/index.php to ~/Code/LocalHomePage/index.php
- $projroot = './LocalHomePage/' and styles still load